### PR TITLE
feat: {{VAR}} placeholder injection in snap copy and TUI finder

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/O-Aditya/snippet-snap/internal/clipboard"
 	"github.com/O-Aditya/snippet-snap/internal/db"
 	"github.com/O-Aditya/snippet-snap/internal/inject"
+	"github.com/O-Aditya/snippet-snap/internal/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -24,26 +25,28 @@ contains {{VAR}} placeholders, you will be prompted for values.`,
 
 		snippet, err := db.GetSnippetByID(getDB(), id)
 		if err != nil {
-			return fmt.Errorf("get snippet: %w", err)
+			return fmt.Errorf("copy: snippet not found: %w", err)
 		}
 
-		// Resolve any {{VAR}} placeholders
-		vars := inject.FindVars(snippet.Content)
-		resolved := snippet.Content
-		if len(vars) > 0 {
-			fmt.Println("This snippet has placeholders. Enter values:")
-			var err error
-			resolved, err = inject.ResolveVars(snippet.Content)
-			if err != nil {
-				return fmt.Errorf("resolve vars: %w", err)
-			}
+		// ResolveVars handles both cases:
+		// — no vars: returns content unchanged immediately
+		// — has vars: prompts user on stderr, returns resolved
+		resolved, err := inject.ResolveVars(snippet.Content)
+		if err != nil {
+			tui.PrintInfo("Aborted.")
+			return nil
 		}
 
 		if err := clipboard.Copy(resolved); err != nil {
-			return fmt.Errorf("copy: %w", err)
+			return fmt.Errorf("copy: clipboard error: %w", err)
 		}
 
-		fmt.Printf("✓ Copied to clipboard (%s)\n", snippet.Alias)
+		vars := inject.FindVars(snippet.Content)
+		if len(vars) > 0 {
+			tui.PrintSuccess(fmt.Sprintf("Copied %s (%d var(s) resolved)", snippet.Alias, len(vars)))
+		} else {
+			tui.PrintSuccess("Copied " + snippet.Alias)
+		}
 		return nil
 	},
 }

--- a/internal/inject/inject.go
+++ b/internal/inject/inject.go
@@ -6,15 +6,28 @@ import (
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
-// varPattern matches {{VAR_NAME}} placeholders where VAR_NAME starts with
+// varRegex matches {{VAR_NAME}} placeholders where name starts with
 // an uppercase letter followed by uppercase letters, digits, or underscores.
-var varPattern = regexp.MustCompile(`\{\{([A-Z][A-Z0-9_]*)\}\}`)
+var varRegex = regexp.MustCompile(`\{\{([A-Z][A-Z0-9_]*)\}\}`)
+
+// Local styles — no tui import to avoid circular dependency.
+var (
+	promptDim    = lipgloss.NewStyle().Foreground(lipgloss.Color("#636E7B"))
+	promptAccent = lipgloss.NewStyle().Foreground(lipgloss.Color("#CBA135")).Bold(true)
+	promptErr    = lipgloss.NewStyle().Foreground(lipgloss.Color("#F85149")).Bold(true)
+)
 
 // FindVars returns a deduplicated, ordered list of variable names found in content.
+// Returns nil if no vars are found. Preserves first-occurrence order.
 func FindVars(content string) []string {
-	matches := varPattern.FindAllStringSubmatch(content, -1)
+	matches := varRegex.FindAllStringSubmatch(content, -1)
+	if len(matches) == 0 {
+		return nil
+	}
 	seen := make(map[string]bool)
 	var vars []string
 	for _, m := range matches {
@@ -28,39 +41,51 @@ func FindVars(content string) []string {
 }
 
 // ResolveVars scans content for {{VAR}} placeholders, prompts the user for
-// each unique variable, and returns the content with all placeholders replaced.
+// each unique variable on stderr/stdin, and returns the content with all
+// placeholders replaced. If no vars are found, returns content unchanged.
 func ResolveVars(content string) (string, error) {
 	vars := FindVars(content)
-	if len(vars) == 0 {
+	if vars == nil {
 		return content, nil
 	}
 
-	scanner := bufio.NewScanner(os.Stdin)
-	resolved := content
+	fmt.Fprintln(os.Stderr,
+		promptDim.Render("  resolving ")+
+			promptAccent.Render(fmt.Sprintf("%d", len(vars)))+
+			promptDim.Render(" variable(s)"))
+
+	reader := bufio.NewReader(os.Stdin)
+	values := make(map[string]string, len(vars))
 
 	for _, name := range vars {
-		fmt.Printf("  %s: ", name)
-		if !scanner.Scan() {
+		fmt.Fprint(os.Stderr, promptAccent.Render("  "+name+" › "))
+
+		line, err := reader.ReadString('\n')
+		if err != nil {
 			return "", fmt.Errorf("input cancelled")
 		}
-		value := strings.TrimSpace(scanner.Text())
-		placeholder := "{{" + name + "}}"
-		resolved = strings.ReplaceAll(resolved, placeholder, value)
+		value := strings.TrimSpace(line)
+
+		// Re-prompt once on empty input
+		if value == "" {
+			fmt.Fprint(os.Stderr, promptErr.Render("  (required) ")+promptAccent.Render(name+" › "))
+			line, err = reader.ReadString('\n')
+			if err != nil {
+				return "", fmt.Errorf("input cancelled")
+			}
+			value = strings.TrimSpace(line)
+			if value == "" {
+				return "", fmt.Errorf("aborted: %s is required", name)
+			}
+		}
+
+		values[name] = value
 	}
 
-	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("read input: %w", err)
+	resolved := content
+	for name, value := range values {
+		resolved = strings.ReplaceAll(resolved, "{{"+name+"}}", value)
 	}
 
 	return resolved, nil
-}
-
-// ResolveVarsWithMap replaces all {{VAR}} placeholders using the provided map.
-// This is useful for non-interactive injection (e.g., from the TUI).
-func ResolveVarsWithMap(content string, values map[string]string) string {
-	for name, value := range values {
-		placeholder := "{{" + name + "}}"
-		content = strings.ReplaceAll(content, placeholder, value)
-	}
-	return content
 }

--- a/internal/inject/inject_test.go
+++ b/internal/inject/inject_test.go
@@ -1,0 +1,97 @@
+package inject
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestFindVars(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect []string
+	}{
+		{
+			name:   "no vars",
+			input:  "no vars here",
+			expect: nil,
+		},
+		{
+			name:   "single var",
+			input:  "echo {{NAME}}",
+			expect: []string{"NAME"},
+		},
+		{
+			name:   "two vars",
+			input:  "{{HOST}}:{{PORT}}",
+			expect: []string{"HOST", "PORT"},
+		},
+		{
+			name:   "deduped and ordered",
+			input:  "{{A}} {{A}} {{B}}",
+			expect: []string{"A", "B"},
+		},
+		{
+			name:   "lowercase not matched",
+			input:  "{{lowercase}}",
+			expect: nil,
+		},
+		{
+			name:   "mixed valid and invalid",
+			input:  "{{A1}} {{B_C}} {{123}}",
+			expect: []string{"A1", "B_C"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FindVars(tt.input)
+			if !reflect.DeepEqual(got, tt.expect) {
+				t.Errorf("FindVars(%q) = %v, want %v", tt.input, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestResolveVars_NoVars(t *testing.T) {
+	input := "hello world — no placeholders"
+	got, err := ResolveVars(input)
+	if err != nil {
+		t.Fatalf("ResolveVars() unexpected error: %v", err)
+	}
+	if got != input {
+		t.Errorf("ResolveVars() = %q, want %q", got, input)
+	}
+}
+
+func TestResolveVars_WithVars(t *testing.T) {
+	// Create a pipe to simulate stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error: %v", err)
+	}
+
+	// Write simulated input before calling ResolveVars
+	_, err = w.WriteString("myhost\n8080\n")
+	if err != nil {
+		t.Fatalf("write to pipe: %v", err)
+	}
+	w.Close()
+
+	// Replace stdin with our pipe
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	input := "curl https://{{HOST}}:{{PORT}}/api"
+	got, resolveErr := ResolveVars(input)
+	if resolveErr != nil {
+		t.Fatalf("ResolveVars() unexpected error: %v", resolveErr)
+	}
+
+	expected := "curl https://myhost:8080/api"
+	if got != expected {
+		t.Errorf("ResolveVars() = %q, want %q", got, expected)
+	}
+}

--- a/internal/tui/finder.go
+++ b/internal/tui/finder.go
@@ -105,21 +105,30 @@ func (f Finder) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return f, nil
 
 		case key.Matches(msg, f.keys.Enter):
-			if len(f.filtered) > 0 {
-				selected := f.filtered[f.cursor]
-				content := selected.Content
+			if len(f.filtered) == 0 {
+				return f, nil
+			}
+			selected := f.filtered[f.cursor]
 
-				vars := inject.FindVars(content)
-				if len(vars) > 0 {
-					f.statusMsg = fmt.Sprintf("✓ Copied %s (%d vars — use 'snap copy %d' to fill)",
-						selected.Alias, len(vars), selected.ID)
-				} else {
-					f.statusMsg = fmt.Sprintf("✓ Copied %s", selected.Alias)
-				}
+			// ResolveVars handles both cases:
+			// — no vars: returns content unchanged immediately
+			// — has vars: prompts user on stderr, returns resolved
+			resolved, err := inject.ResolveVars(selected.Content)
+			if err != nil {
+				f.statusMsg = "✗ Aborted"
+				return f, nil
+			}
 
-				if err := clipboard.Copy(content); err != nil {
-					f.statusMsg = fmt.Sprintf("✗ Copy failed: %v", err)
-				}
+			if err := clipboard.Copy(resolved); err != nil {
+				f.statusMsg = fmt.Sprintf("✗ Copy failed: %v", err)
+				return f, nil
+			}
+
+			vars := inject.FindVars(selected.Content)
+			if len(vars) > 0 {
+				f.statusMsg = fmt.Sprintf("✓ Copied %s (%d var(s) resolved)", selected.Alias, len(vars))
+			} else {
+				f.statusMsg = "✓ Copied " + selected.Alias
 			}
 			return f, nil
 


### PR DESCRIPTION
## Summary
Implements full {{VAR}} injection pipeline for snap copy and the TUI finder enter key. Closes #1

## Changes
- internal/inject/inject.go — FindVars + ResolveVars with styled prompts
- internal/inject/inject_test.go — table-driven tests for both functions
- cmd/copy.go — ResolveVars called before clipboard write
- internal/tui/finder.go — enter key triggers resolution flow

## How to test
1. Add a snippet with {{VAR}} in content:
   `snap add --name test-var --lang bash`
   Content: `curl https://{{HOST}}/{{PATH}}`

2. Test via copy command:
   `snap copy <id>`
   Should prompt: HOST > then PATH >
   Then: Copied test-var (2 var(s) resolved)

3. Test via TUI:
   `snap find` -> select test-var -> enter
   Same prompt flow, same success message

4. Test no-var snippet:
   `snap copy <id-with-no-vars>`
   Should copy immediately, no prompts

5. Test abort:
   `snap copy <id-with-vars>` -> press enter twice on a required var
   Should print: Aborted.

## Checklist
- [x] FindVars deduplicates and preserves order
- [x] ResolveVars re-prompts once on empty input
- [x] Abort on second empty returns error, not panic
- [x] TUI enter key works for both var and no-var snippets
- [x] No regression on snap list, snap add, snap find navigation
- [x] All 8 inject tests pass

Closes #1