### PR TITLE
fix: resolve {{VAR}} input freeze inside snip find TUI

### DIFF
--- a/cmd/find.go
+++ b/cmd/find.go
@@ -2,10 +2,14 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"golang.org/x/term"
 
+	"github.com/O-Aditya/snippet-snap/internal/clipboard"
 	"github.com/O-Aditya/snippet-snap/internal/db"
+	"github.com/O-Aditya/snippet-snap/internal/inject"
 	"github.com/O-Aditya/snippet-snap/internal/tui"
 	"github.com/spf13/cobra"
 )
@@ -23,15 +27,47 @@ direct clipboard copy.`,
 		}
 
 		if len(snippets) == 0 {
-			fmt.Println("No snippets yet. Use 'snap add' to create one.")
+			fmt.Println("No snippets yet. Use 'snip add' to create one.")
 			return nil
 		}
+
+		// Save terminal state BEFORE Bubble Tea takes over.
+		// On Windows, the TUI's cancelreader can leave the console
+		// in a semi-raw state after exit. This guarantees we can
+		// restore cooked mode for var prompts later.
+		fd := int(os.Stdin.Fd())
+		savedState, stateErr := term.GetState(fd)
 
 		finder := tui.NewFinder(snippets)
 		p := tea.NewProgram(finder, tea.WithAltScreen())
 
-		if _, err := p.Run(); err != nil {
+		finalModel, err := p.Run()
+		if err != nil {
 			return fmt.Errorf("tui: %w", err)
+		}
+
+		// If the user selected a snippet with {{VAR}} placeholders,
+		// resolve vars now that the TUI has exited.
+		f := finalModel.(tui.Finder)
+		if f.SelectedSnippet != nil {
+			// Force-restore terminal to cooked mode so stdin reads work.
+			if stateErr == nil {
+				_ = term.Restore(fd, savedState)
+			}
+
+			selected := f.SelectedSnippet
+			resolved, err := inject.ResolveVars(selected.Content)
+			if err != nil {
+				tui.PrintInfo("Aborted.")
+				return nil
+			}
+
+			if err := clipboard.Copy(resolved); err != nil {
+				return fmt.Errorf("copy: clipboard error: %w", err)
+			}
+
+			vars := inject.FindVars(selected.Content)
+			tui.PrintSuccess(fmt.Sprintf("Copied %s (%d var(s) resolved)", selected.Alias, len(vars)))
 		}
 
 		return nil

--- a/internal/tui/finder.go
+++ b/internal/tui/finder.go
@@ -18,17 +18,18 @@ import (
 
 // Finder is the Bubble Tea model for the `snap find` TUI.
 type Finder struct {
-	allSnippets []models.Snippet
-	filtered    []models.Snippet
-	cursor      int
-	searchInput textinput.Model
-	preview     viewport.Model
-	keys        KeyMap
-	width       int
-	height      int
-	showPreview bool
-	statusMsg   string
-	quitting    bool
+	allSnippets      []models.Snippet
+	filtered         []models.Snippet
+	cursor           int
+	searchInput      textinput.Model
+	preview          viewport.Model
+	keys             KeyMap
+	width            int
+	height           int
+	showPreview      bool
+	statusMsg        string
+	quitting         bool
+	SelectedSnippet  *models.Snippet // set when a snippet with {{VAR}} needs resolution after TUI exits
 }
 
 // NewFinder creates a new Finder model with the given snippets.
@@ -110,26 +111,22 @@ func (f Finder) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			selected := f.filtered[f.cursor]
 
-			// ResolveVars handles both cases:
-			// — no vars: returns content unchanged immediately
-			// — has vars: prompts user on stderr, returns resolved
-			resolved, err := inject.ResolveVars(selected.Content)
-			if err != nil {
-				f.statusMsg = "✗ Aborted"
-				return f, nil
+			// Check if snippet has {{VAR}} placeholders
+			vars := inject.FindVars(selected.Content)
+			if len(vars) > 0 {
+				// Has vars — quit TUI so stdin returns to cooked mode.
+				// The caller (cmd/find.go) handles ResolveVars after exit.
+				f.SelectedSnippet = &selected
+				f.quitting = true
+				return f, tea.Quit
 			}
 
-			if err := clipboard.Copy(resolved); err != nil {
+			// No vars — copy immediately
+			if err := clipboard.Copy(selected.Content); err != nil {
 				f.statusMsg = fmt.Sprintf("✗ Copy failed: %v", err)
 				return f, nil
 			}
-
-			vars := inject.FindVars(selected.Content)
-			if len(vars) > 0 {
-				f.statusMsg = fmt.Sprintf("✓ Copied %s (%d var(s) resolved)", selected.Alias, len(vars))
-			} else {
-				f.statusMsg = "✓ Copied " + selected.Alias
-			}
+			f.statusMsg = "✓ Copied " + selected.Alias
 			return f, nil
 
 		case key.Matches(msg, f.keys.PageUp):


### PR DESCRIPTION
## Problem
When a snippet contains `{{VAR}}` placeholders and the user presses Enter inside `snip find`, the var prompt appears but keyboard input is not registered. Bubble Tea owns stdin in raw mode.

## Root Cause
`inject.ResolveVars()` was called synchronously inside the TUI Update() handler while Bubble Tea held stdin in raw mode.

## Fix
- **finder.go**: When Enter is pressed on a snippet with vars, store it in `SelectedSnippet` and `tea.Quit`
- **find.go**: After `p.Run()` returns, restore terminal with `term.Restore()` then call `ResolveVars()` in cooked-mode stdin

## Files Changed
- `internal/tui/finder.go` — Enter handler branches on vars
- `cmd/find.go` — post-TUI var resolution + terminal restore

## Testing
1. `snip find` → select snippet with `{{VAR}}` → Enter
2. TUI exits → var prompt appears → typing works → Copied
3. No-var snippets still copy instantly inside TUI